### PR TITLE
Switch to implementing pasts' notifier instead of implementing future

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,10 +46,12 @@ features = [
 [target.'cfg(target_arch = "wasm32")'.dependencies.wasm-bindgen]
 version = "0.2"
 
+[dependencies]
+pasts = "0.11.0"
+
 [build-dependencies]
 
 [dev-dependencies]
-pasts = "0.11"
 devout = "0.2"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
<!--- Please describe the changes in the PR and the motivation below -->
updated Cargo.toml to include pasts outside of dev-dependencies, and updated input.rs to implement pasts instead of futures
<!--- Check CONTRIBUTING.md for more information-->

